### PR TITLE
Metadata in MPRISv2 should be a dict, not an array of dict

### DIFF
--- a/mpris_common.c
+++ b/mpris_common.c
@@ -155,7 +155,6 @@ GVariant* get_metadata_v2(int track_id)
     deadbeef -> plt_unref(pl);
 
     GVariant *tmp;
-    GVariant *ret = NULL;
 
     GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE("a{sv}"));
     if(track == NULL){
@@ -218,16 +217,9 @@ GVariant* get_metadata_v2(int track_id)
 no_track_playing:
     tmp = g_variant_builder_end(builder);
 
-    /*
-     * We need a tuple containing a array of dict.
-     */
-    GVariantBuilder *ret_builder = g_variant_builder_new(G_VARIANT_TYPE("(a{sv})"));
-    g_variant_builder_add_value(ret_builder, tmp);
-    ret = g_variant_builder_end(ret_builder);
     g_variant_builder_unref(builder);
-    g_variant_builder_unref(ret_builder);
 
-    return ret;
+    return tmp;
 }
 /*
  * Set the loop status.


### PR DESCRIPTION
I'm coding an MPRISv2 client ruby gem. When getting track metadata from different players, i've noticed i was getting an array from deadbeef, not a hash.

<pre>
$ ruby -rubygems examples/metadata.rb 
Rhythmbox:
{"xesam:trackNumber"=>1,
 "xesam:artist"=>["Massacre"],
 "xesam:useCount"=>0,
 "xesam:userRating"=>0.0,
 "mpris:length"=>275000000,
 "xesam:audioBitrate"=>131072,
 "xesam:genre"=>["Other"],
 "xesam:album"=>"L\302\264alma occulta",
 "xesam:title"=>"Juicio A Un Bailarin",
 "xesam:url"=>
  "file:///media/SAMSUNG/Downloads/Musica/Clean/Massacre/L'alma%20occulta/01-Juicio%20A%20Un%20Bailarin.mp3",
 "mpris:trackid"=>"/org/mpris/MediaPlayer2/Track/20"}
Banshee:
{"xesam:trackNumber"=>1,
 "xesam:albumArtist"=>["Massacre"],
 "mpris:artUrl"=>
  "file:///home/federico/.cache/media-art/album-66fd152d0cee69d06289f70910415d5f.jpg",
 "xesam:artist"=>["Massacre"],
 "mpris:length"=>276223000,
 "xesam:genre"=>["Other"],
 "xesam:album"=>"L\302\264alma occulta",
 "xesam:title"=>"Juicio A Un Bailarin",
 "xesam:url"=>
  "file:///media/SAMSUNG/Downloads/Musica/Clean/Massacre/L'alma%20occulta/01-Juicio%20A%20Un%20Bailarin.mp3",
 "mpris:trackid"=>"/org/bansheeproject/Banshee/Track/6911908"}
DeaDBeeF:
[{"xesam:albumArtist"=>"Massacre",
 "xesam:artist"=>"Massacre",
 "mpris:length"=>275000,
 "xesam:url"=>
  "file:///media/SAMSUNG/Downloads/Musica/Clean/Massacre/L'alma occulta/01-Juicio A Un Bailarin.mp3",
 "xesam:genre"=>"Other",
 "xesam:title"=>"Juicio A Un Bailarin",
 "xesam:album"=>"L\302\264alma occulta",
 "mpris:trackid"=>"/org/mpris/MediaPlayer2/Track/track0"}]
</pre>


I compared it to Rhythmbox and Banshee, two major players used in desktop-oriented Gnome-based distros like Ubuntu or Fedora. This way i could know if i misunderstood the MPRISv2 Spec and its "a{sv}".

Looking in [glib's documentation](http://developer.gnome.org/glib/2.28/glib-GVariantType.html):

> {} - used to enclose a basic type string concatenated with another type string to create a dictionary entry type, which usually appears inside of an array to form a dictionary; the type string "a{sd}", for example, is the type of a dictionary that maps strings to double precision floating point values.

I've also checked source code for Rhythmbox MPRISv2 plugin, the Banshee one, and even Amarok. They all use Hashes to return metadata:

[Rhythmbox's rb-client.c](http://git.gnome.org/browse/rhythmbox/tree/remote/dbus/rb-client.c):

<pre>
static GHashTable *
get_playing_song_info (GDBusProxy *mpris)
</pre>


[Banshee's Banshee.Mpris](http://git.gnome.org/browse/banshee/tree/src/Extensions/Banshee.Mpris/Banshee.Mpris/MediaPlayer.cs):

<pre>
public IDictionary<string, object> Metadata {
</pre>


[Amarok's Mpris2DBusHandler.cpp](http://quickgit.kde.org/index.php?p=amarok.git&a=blob_plain&h=fc69d499272743acf0cf3910e028ebfc62a3b73f&f=src/dbus/mpris2/Mpris2DBusHandler.cpp):

<pre>
QVariantMap metaData = Meta::Field::mpris20MapFromTrack( currentTrack );
</pre>


I'd like to know your opinion on this subject. And thanks again for this userful plugin!
