### PR TITLE
Fix errors on compile and fix volume value while control from mpris client

### DIFF
--- a/build-aux/ltmain.sh
+++ b/build-aux/ltmain.sh
@@ -1,9 +1,9 @@
 
-# libtool (GNU libtool) 2.4
+# libtool (GNU libtool) 2.4.2
 # Written by Gordon Matzigkeit <gord@gnu.ai.mit.edu>, 1996
 
 # Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2004, 2005, 2006,
-# 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
+# 2007, 2008, 2009, 2010, 2011 Free Software Foundation, Inc.
 # This is free software; see the source for copying conditions.  There is NO
 # warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
@@ -41,6 +41,7 @@
 #       --quiet, --silent    don't print informational messages
 #       --no-quiet, --no-silent
 #                            print informational messages (default)
+#       --no-warn            don't display warning messages
 #       --tag=TAG            use configuration variables from tag TAG
 #   -v, --verbose            print more informational messages than default
 #       --no-verbose         don't print the extra informational messages
@@ -69,7 +70,7 @@
 #         compiler:		$LTCC
 #         compiler flags:		$LTCFLAGS
 #         linker:		$LD (gnu? $with_gnu_ld)
-#         $progname:	(GNU libtool) 2.4
+#         $progname:	(GNU libtool) 2.4.2 Debian-2.4.2-1.3
 #         automake:	$automake_version
 #         autoconf:	$autoconf_version
 #
@@ -79,9 +80,9 @@
 
 PROGRAM=libtool
 PACKAGE=libtool
-VERSION=2.4
+VERSION="2.4.2 Debian-2.4.2-1.3"
 TIMESTAMP=""
-package_revision=1.3293
+package_revision=1.3337
 
 # Be Bourne compatible
 if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then
@@ -136,15 +137,10 @@ progpath="$0"
 
 : ${CP="cp -f"}
 test "${ECHO+set}" = set || ECHO=${as_echo-'printf %s\n'}
-: ${EGREP="grep -E"}
-: ${FGREP="grep -F"}
-: ${GREP="grep"}
-: ${LN_S="ln -s"}
 : ${MAKE="make"}
 : ${MKDIR="mkdir"}
 : ${MV="mv -f"}
 : ${RM="rm -f"}
-: ${SED="sed"}
 : ${SHELL="${CONFIG_SHELL-/bin/sh}"}
 : ${Xsed="$SED -e 1s/^X//"}
 
@@ -387,7 +383,7 @@ case $progpath in
      ;;
   *)
      save_IFS="$IFS"
-     IFS=:
+     IFS=${PATH_SEPARATOR-:}
      for progdir in $PATH; do
        IFS="$save_IFS"
        test -x "$progdir/$progname" && break
@@ -771,8 +767,8 @@ func_help ()
 	s*\$LTCFLAGS*'"$LTCFLAGS"'*
 	s*\$LD*'"$LD"'*
 	s/\$with_gnu_ld/'"$with_gnu_ld"'/
-	s/\$automake_version/'"`(automake --version) 2>/dev/null |$SED 1q`"'/
-	s/\$autoconf_version/'"`(autoconf --version) 2>/dev/null |$SED 1q`"'/
+	s/\$automake_version/'"`(${AUTOMAKE-automake} --version) 2>/dev/null |$SED 1q`"'/
+	s/\$autoconf_version/'"`(${AUTOCONF-autoconf} --version) 2>/dev/null |$SED 1q`"'/
 	p
 	d
      }
@@ -1052,6 +1048,7 @@ opt_finish=false
 opt_help=false
 opt_help_all=false
 opt_silent=:
+opt_warning=:
 opt_verbose=:
 opt_silent=false
 opt_verbose=false
@@ -1118,6 +1115,10 @@ esac
 			;;
       --no-silent|--no-quiet)
 			opt_silent=false
+func_append preserve_args " $opt"
+			;;
+      --no-warning|--no-warn)
+			opt_warning=false
 func_append preserve_args " $opt"
 			;;
       --no-verbose)
@@ -2059,7 +2060,7 @@ func_mode_compile ()
     *.[cCFSifmso] | \
     *.ada | *.adb | *.ads | *.asm | \
     *.c++ | *.cc | *.ii | *.class | *.cpp | *.cxx | \
-    *.[fF][09]? | *.for | *.java | *.obj | *.sx | *.cu | *.cup)
+    *.[fF][09]? | *.for | *.java | *.go | *.obj | *.sx | *.cu | *.cup)
       func_xform "$libobj"
       libobj=$func_xform_result
       ;;
@@ -3201,11 +3202,13 @@ func_mode_install ()
 
       # Set up the ranlib parameters.
       oldlib="$destdir/$name"
+      func_to_tool_file "$oldlib" func_convert_file_msys_to_w32
+      tool_oldlib=$func_to_tool_file_result
 
       func_show_eval "$install_prog \$file \$oldlib" 'exit $?'
 
       if test -n "$stripme" && test -n "$old_striplib"; then
-	func_show_eval "$old_striplib $oldlib" 'exit $?'
+	func_show_eval "$old_striplib $tool_oldlib" 'exit $?'
       fi
 
       # Do each command in the postinstall commands.
@@ -3470,7 +3473,7 @@ static const void *lt_preloaded_setup() {
 	  # linked before any other PIC object.  But we must not use
 	  # pic_flag when linking with -static.  The problem exists in
 	  # FreeBSD 2.2.6 and is fixed in FreeBSD 3.1.
-	  *-*-freebsd2*|*-*-freebsd3.0*|*-*-freebsdelf3.0*)
+	  *-*-freebsd2.*|*-*-freebsd3.0*|*-*-freebsdelf3.0*)
 	    pic_flag_for_symtable=" $pic_flag -DFREEBSD_WORKAROUND" ;;
 	  *-*-hpux*)
 	    pic_flag_for_symtable=" $pic_flag"  ;;
@@ -3982,14 +3985,17 @@ func_exec_program_core ()
 # launches target application with the remaining arguments.
 func_exec_program ()
 {
-  for lt_wr_arg
-  do
-    case \$lt_wr_arg in
-    --lt-*) ;;
-    *) set x \"\$@\" \"\$lt_wr_arg\"; shift;;
-    esac
-    shift
-  done
+  case \" \$* \" in
+  *\\ --lt-*)
+    for lt_wr_arg
+    do
+      case \$lt_wr_arg in
+      --lt-*) ;;
+      *) set x \"\$@\" \"\$lt_wr_arg\"; shift;;
+      esac
+      shift
+    done ;;
+  esac
   func_exec_program_core \${1+\"\$@\"}
 }
 
@@ -5057,9 +5063,15 @@ void lt_dump_script (FILE* f)
 {
 EOF
 	    func_emit_wrapper yes |
-              $SED -e 's/\([\\"]\)/\\\1/g' \
-	           -e 's/^/  fputs ("/' -e 's/$/\\n", f);/'
-
+	      $SED -n -e '
+s/^\(.\{79\}\)\(..*\)/\1\
+\2/
+h
+s/\([\\"]\)/\\\1/g
+s/$/\\n/
+s/\([^\n]*\).*/  fputs ("\1", f);/p
+g
+D'
             cat <<"EOF"
 }
 EOF
@@ -5643,7 +5655,8 @@ func_mode_link ()
 	continue
 	;;
 
-      -mt|-mthreads|-kthread|-Kthread|-pthread|-pthreads|--thread-safe|-threads)
+      -mt|-mthreads|-kthread|-Kthread|-pthread|-pthreads|--thread-safe \
+      |-threads|-fopenmp|-openmp|-mp|-xopenmp|-omp|-qsmp=*)
 	func_append compiler_flags " $arg"
 	func_append compile_command " $arg"
 	func_append finalize_command " $arg"
@@ -6111,7 +6124,10 @@ func_mode_link ()
 	case $pass in
 	dlopen) libs="$dlfiles" ;;
 	dlpreopen) libs="$dlprefiles" ;;
-	link) libs="$deplibs %DEPLIBS% $dependency_libs" ;;
+	link)
+	  libs="$deplibs %DEPLIBS%"
+	  test "X$link_all_deplibs" != Xno && libs="$libs $dependency_libs"
+	  ;;
 	esac
       fi
       if test "$linkmode,$pass" = "lib,dlpreopen"; then
@@ -6147,7 +6163,8 @@ func_mode_link ()
 	lib=
 	found=no
 	case $deplib in
-	-mt|-mthreads|-kthread|-Kthread|-pthread|-pthreads|--thread-safe|-threads)
+	-mt|-mthreads|-kthread|-Kthread|-pthread|-pthreads|--thread-safe \
+        |-threads|-fopenmp|-openmp|-mp|-xopenmp|-omp|-qsmp=*)
 	  if test "$linkmode,$pass" = "prog,link"; then
 	    compile_deplibs="$deplib $compile_deplibs"
 	    finalize_deplibs="$deplib $finalize_deplibs"
@@ -6430,19 +6447,19 @@ func_mode_link ()
 	    # It is a libtool convenience library, so add in its objects.
 	    func_append convenience " $ladir/$objdir/$old_library"
 	    func_append old_convenience " $ladir/$objdir/$old_library"
+	    tmp_libs=
+	    for deplib in $dependency_libs; do
+	      deplibs="$deplib $deplibs"
+	      if $opt_preserve_dup_deps ; then
+		case "$tmp_libs " in
+		*" $deplib "*) func_append specialdeplibs " $deplib" ;;
+		esac
+	      fi
+	      func_append tmp_libs " $deplib"
+	    done
 	  elif test "$linkmode" != prog && test "$linkmode" != lib; then
 	    func_fatal_error "\`$lib' is not a convenience library"
 	  fi
-	  tmp_libs=
-	  for deplib in $dependency_libs; do
-	    deplibs="$deplib $deplibs"
-	    if $opt_preserve_dup_deps ; then
-	      case "$tmp_libs " in
-	      *" $deplib "*) func_append specialdeplibs " $deplib" ;;
-	      esac
-	    fi
-	    func_append tmp_libs " $deplib"
-	  done
 	  continue
 	fi # $pass = conv
 
@@ -6831,7 +6848,7 @@ func_mode_link ()
 	         test "$hardcode_direct_absolute" = no; then
 		add="$dir/$linklib"
 	      elif test "$hardcode_minus_L" = yes; then
-		add_dir="-L$dir"
+		add_dir="-L$absdir"
 		# Try looking first in the location we're being installed to.
 		if test -n "$inst_prefix_dir"; then
 		  case $libdir in
@@ -7316,6 +7333,7 @@ func_mode_link ()
 	  # which has an extra 1 added just for fun
 	  #
 	  case $version_type in
+	  # correct linux to gnu/linux during the next big refactor
 	  darwin|linux|osf|windows|none)
 	    func_arith $number_major + $number_minor
 	    current=$func_arith_result
@@ -7333,6 +7351,9 @@ func_mode_link ()
 	    age="$number_minor"
 	    revision="$number_minor"
 	    lt_irix_increment=no
+	    ;;
+	  *)
+	    func_fatal_configuration "$modename: unknown library version type \`$version_type'"
 	    ;;
 	  esac
 	  ;;
@@ -7432,7 +7453,7 @@ func_mode_link ()
 	  versuffix="$major.$revision"
 	  ;;
 
-	linux)
+	linux) # correct to gnu/linux during the next big refactor
 	  func_arith $current - $age
 	  major=.$func_arith_result
 	  versuffix="$major.$age.$revision"
@@ -8020,6 +8041,11 @@ EOF
 
       # Test again, we may have decided not to build it any more
       if test "$build_libtool_libs" = yes; then
+	# Remove ${wl} instances when linking with ld.
+	# FIXME: should test the right _cmds variable.
+	case $archive_cmds in
+	  *\$LD\ *) wl= ;;
+        esac
 	if test "$hardcode_into_libs" = yes; then
 	  # Hardcode the library paths
 	  hardcode_libdirs=
@@ -8050,7 +8076,7 @@ EOF
 	    elif test -n "$runpath_var"; then
 	      case "$perm_rpath " in
 	      *" $libdir "*) ;;
-	      *) func_apped perm_rpath " $libdir" ;;
+	      *) func_append perm_rpath " $libdir" ;;
 	      esac
 	    fi
 	  done
@@ -8058,11 +8084,7 @@ EOF
 	  if test -n "$hardcode_libdir_separator" &&
 	     test -n "$hardcode_libdirs"; then
 	    libdir="$hardcode_libdirs"
-	    if test -n "$hardcode_libdir_flag_spec_ld"; then
-	      eval dep_rpath=\"$hardcode_libdir_flag_spec_ld\"
-	    else
-	      eval dep_rpath=\"$hardcode_libdir_flag_spec\"
-	    fi
+	    eval "dep_rpath=\"$hardcode_libdir_flag_spec\""
 	  fi
 	  if test -n "$runpath_var" && test -n "$perm_rpath"; then
 	    # We should set the runpath_var.
@@ -9152,6 +9174,8 @@ EOF
 	    esac
 	  done
 	fi
+	func_to_tool_file "$oldlib" func_convert_file_msys_to_w32
+	tool_oldlib=$func_to_tool_file_result
 	eval cmds=\"$old_archive_cmds\"
 
 	func_len " $cmds"
@@ -9261,7 +9285,8 @@ EOF
 	      *.la)
 		func_basename "$deplib"
 		name="$func_basename_result"
-		eval libdir=`${SED} -n -e 's/^libdir=\(.*\)$/\1/p' $deplib`
+		func_resolve_sysroot "$deplib"
+		eval libdir=`${SED} -n -e 's/^libdir=\(.*\)$/\1/p' $func_resolve_sysroot_result`
 		test -z "$libdir" && \
 		  func_fatal_error "\`$deplib' is not a valid libtool archive"
 		func_append newdependency_libs " ${lt_sysroot:+=}$libdir/$name"

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_INIT([deadbeef], [2.1.5], [huangcongyu2006@gmail.com])
 AC_CONFIG_HEADER(config.h)
 AC_CONFIG_AUX_DIR([build-aux])
-AM_INIT_AUTOMAKE([deadbeef], [2.1.5], [huangcongyu2006@gmail.com])
+AM_INIT_AUTOMAKE
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CC

--- a/m4/ltversion.m4
+++ b/m4/ltversion.m4
@@ -9,15 +9,15 @@
 
 # @configure_input@
 
-# serial 3293 ltversion.m4
+# serial 3337 ltversion.m4
 # This file is part of GNU Libtool
 
-m4_define([LT_PACKAGE_VERSION], [2.4])
-m4_define([LT_PACKAGE_REVISION], [1.3293])
+m4_define([LT_PACKAGE_VERSION], [2.4.2])
+m4_define([LT_PACKAGE_REVISION], [1.3337])
 
 AC_DEFUN([LTVERSION_VERSION],
-[macro_version='2.4'
-macro_revision='1.3293'
+[macro_version='2.4.2'
+macro_revision='1.3337'
 _LT_DECL(, macro_version, 0, [Which release of libtool.m4 was used?])
 _LT_DECL(, macro_revision, 0)
 ])

--- a/mpris.c
+++ b/mpris.c
@@ -54,12 +54,18 @@ static gpointer server_thread(gpointer data)
 
 static gint mpris_start() 
 {
+#if (GLIB_MAJOR_VERSION <= 2 && GLIB_MINOR_VERSION < 32)
     if(!g_thread_supported()){
         g_thread_init(NULL);
         debug("Init the thread...");
     }
+#endif
     GError *err = NULL;
+#if (GLIB_MAJOR_VERSION <= 2 && GLIB_MINOR_VERSION < 32)
     server_thread_id = g_thread_create(server_thread, NULL, FALSE, &err);
+#else
+    server_thread_id = g_thread_new(NULL, server_thread, NULL);
+#endif
     if(server_thread_id == NULL){
         debug("Create MPRIS thread error. %d:%s", err -> code, err -> message);
         g_error_free(err);

--- a/mpris.c
+++ b/mpris.c
@@ -139,6 +139,22 @@ static gint mpris_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2)
             DB_mpris_emit_statuschange_v1();
         }
         break;
+    case DB_EV_VOLUMECHANGED:
+//         if(1 == mpris_v2_enable)
+//         {
+//             float volume = (-2.0 * deadbeef -> volume_get_db() + 100.0) / 100.0;
+//             if(volume > 1.0)
+//             {
+//                 volume = 1.0;
+//             }
+//             if(volume < 0.0)
+//             {
+//                 volume = 0.0;
+//             }
+// 
+//             DB_mpris_emit_volume_change_v2(volume);
+//         }
+        break;
     default:
         break;
     }

--- a/mpris_v1.c
+++ b/mpris_v1.c
@@ -566,8 +566,9 @@ static void on_name_lost (GDBusConnection *connection,
 
 gint DB_mpris_server_start_v1(DB_mpris_server_v1 **srv)
 {
+#if (GLIB_MAJOR_VERSION <= 2 && GLIB_MINOR_VERSION < 36)
     g_type_init();
-
+#endif
     server = g_new(DB_mpris_server_v1, 1);
     if(server == NULL){
         debug("Create DB_mpris_server error!!\n");

--- a/mpris_v2.c
+++ b/mpris_v2.c
@@ -322,10 +322,17 @@ static GVariant *handle_player_get_property(GDBusConnection *connection,
     }else if(g_strcmp0(property_name, "Metadata") == 0){
         ret = get_metadata_v2(-1);
     }else if(g_strcmp0(property_name, "Volume") == 0){
-        float min_vol = deadbeef -> volume_get_min_db();
-        float volume = deadbeef -> volume_get_db() - min_vol;
+        float volume = (-2.0 * deadbeef -> volume_get_db() + 100.0) / 100.0;
+        if(volume > 1.0)
+        {
+            volume = 1.0;
+        }
+        if(volume < 0.0)
+        {
+            volume = 0.0;
+        }
         debug("Get Volume: %f", volume);
-        ret =  g_variant_new("(d)" , volume / ( - min_vol) * 100);
+        ret =  g_variant_new("(d)" , volume );
     }else if(g_strcmp0(property_name, "Position") == 0){
         DB_playItem_t *track = NULL;
         track = deadbeef -> streamer_get_playing_track();
@@ -387,12 +394,16 @@ static gboolean handle_player_set_property(GDBusConnection  *connection,
     }else if(g_strcmp0(property_name, "Volume") == 0){
         double volume = 0;
         g_variant_get(value, "d", &volume);
-        if(volume > 100.0){
-            volume = 100.0;
+        if(volume > 1.0){
+            volume = 1.0;
         }
-        float vol_f = 50 - ((float)volume / 100.0 * 50.0);
-        debug("Set Volume: %f %f", volume, vol_f);
+        if(volume < 0.0){
+            volume = 0.0;
+        }
+        float vol_f = (100.0 - (float)(volume * 100.0))/2.0;
+        debug("Set Volume: %f %f", volume, -vol_f);
         deadbeef -> volume_set_db(-vol_f);
+        //deadbeef -> volume_set_amp((float)volume);
     }
     /*
      * Emit the org.freedesktop.DBus.Properties.PropertiesChanged signal
@@ -403,6 +414,15 @@ static gboolean handle_player_set_property(GDBusConnection  *connection,
                     , "PropertiesChanged", sigpar);
     return TRUE;
 }
+
+// void DB_mpris_emit_volume_change_v2(float volume)
+// {
+//     GVariant *sigvol = g_variant_new("(d)", volume);
+//     debug("Emit PropertiesChanges signal volume: %f\n", volume);
+//     emit_signal(server -> con, "org.freedesktop.DBus.Properties", MPRIS_V2_PATH
+//                     , "PropertiesChanged", sigvol);
+//     //return TRUE;
+// }
 
 void DB_mpris_emit_seeked_v2(gint64 seeked)
 {

--- a/mpris_v2.c
+++ b/mpris_v2.c
@@ -678,8 +678,9 @@ static void on_name_lost (GDBusConnection *connection,
 
 gint DB_mpris_server_start_v2(DB_mpris_server_v2 **srv)
 {
+#if (GLIB_MAJOR_VERSION <= 2 && GLIB_MINOR_VERSION < 36)
     g_type_init();
-
+#endif
     server = g_new(DB_mpris_server_v2, 1);
     if(server == NULL){
         debug("Create DB_mpris_server error!!\n");

--- a/mpris_v2.h
+++ b/mpris_v2.h
@@ -30,4 +30,5 @@ gint DB_mpris_server_stop_v2(DB_mpris_server_v2 *srv);
  */
 void DB_mpris_emit_tracklistchange_v2();
 void DB_mpris_emit_seeked_v2(gint64 seeked);
+// void DB_mpris_emit_volume_change_v2(float volume);
 #endif

--- a/test/test_signal.c
+++ b/test/test_signal.c
@@ -82,9 +82,9 @@ int main(int argc, char **argv)
     }
     GError *error;
     GDBusProxy *proxy;
-
+#if (GLIB_MAJOR_VERSION <= 2 && GLIB_MINOR_VERSION < 36)
     g_type_init ();
-
+#endif
     loop = NULL;
     proxy = NULL;
     loop = g_main_loop_new (NULL, FALSE);


### PR DESCRIPTION
Fix to compile with new glib (2.32 and 2.36 versions)
Now can control sound in deadbeef trunk (0.6) from default mpris client in kde - make correct convertion from mpris value to db
Update configure.ac for new version of autoconf
